### PR TITLE
refactor: rename to fleet provisioning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <fleetprovisioningpluginjar.name>FleetProvisioningPlugin</fleetprovisioningpluginjar.name>
+        <fleetprovisioningpluginjar.name>FleetProvisioning</fleetprovisioningpluginjar.name>
     </properties>
 
     <build>
@@ -272,7 +272,7 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.3.0-SNAPSHOT</version>
+            <version>2.4.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -309,7 +309,7 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.3.0-SNAPSHOT</version>
+            <version>2.4.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/com/aws/greengrass/AwsIotFleetProvisioningPlugin.java
+++ b/src/main/java/com/aws/greengrass/AwsIotFleetProvisioningPlugin.java
@@ -42,7 +42,7 @@ import static com.aws.greengrass.provisioning.ProvisionConfiguration.SystemConfi
 
 public class AwsIotFleetProvisioningPlugin implements DeviceIdentityInterface {
 
-    static final String PLUGIN_NAME = "aws.greengrass.AwsIotFleetProvisioningPlugin";
+    static final String PLUGIN_NAME = "aws.greengrass.FleetProvisioning";
     private static final Logger logger = LogManager.getLogger(AwsIotFleetProvisioningPlugin.class);
 
     // Required parameters


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Removing the keyword 'plugin' from the plugin's name. Changing the name of artifacts to FleetProvisioning.jar

**Why is this change necessary:**

**How was this change tested:**
mvn clean install

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
