### PR TITLE
fix(windows): return paths as file URI instead of just path for private key and cert

### DIFF
--- a/codestyle/findbugs-exclude.xml
+++ b/codestyle/findbugs-exclude.xml
@@ -7,6 +7,7 @@
 <FindBugsFilter>
     <Match>
         <Or>
+            <Bug pattern="DM_CONVERT_CASE"/>
             <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE"/>
             <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
         </Or>

--- a/src/main/java/com/aws/greengrass/FleetProvisioningByClaimPlugin.java
+++ b/src/main/java/com/aws/greengrass/FleetProvisioningByClaimPlugin.java
@@ -70,6 +70,8 @@ public class FleetProvisioningByClaimPlugin implements DeviceIdentityInterface {
     static final String DEVICE_CERTIFICATE_PATH_RELATIVE_TO_ROOT = "/thingCert.crt";
     static final String PRIVATE_KEY_PATH_RELATIVE_TO_ROOT = "/privKey.key";
 
+    public static final boolean IS_WINDOWS = System.getProperty("os.name").toLowerCase().contains("wind");
+
     private final IotIdentityHelperFactory iotIdentityHelperFactory;
     private final MqttConnectionHelper mqttConnectionHelper;
 
@@ -204,10 +206,10 @@ public class FleetProvisioningByClaimPlugin implements DeviceIdentityInterface {
 
         SystemConfiguration systemConfiguration = SystemConfiguration.builder()
                 .thingName(registerThingResponse.thingName)
-                .privateKeyPath(parameterMap.get(ROOT_PATH_PARAMETER_NAME).toString()
-                        + PRIVATE_KEY_PATH_RELATIVE_TO_ROOT)
-                .certificateFilePath(parameterMap.get(ROOT_PATH_PARAMETER_NAME).toString()
-                        + DEVICE_CERTIFICATE_PATH_RELATIVE_TO_ROOT)
+                .privateKeyPath(getFileUriOrString(Paths.get(parameterMap.get(ROOT_PATH_PARAMETER_NAME).toString(),
+                        PRIVATE_KEY_PATH_RELATIVE_TO_ROOT)))
+                .certificateFilePath(getFileUriOrString(Paths.get(parameterMap.get(ROOT_PATH_PARAMETER_NAME).toString(),
+                        DEVICE_CERTIFICATE_PATH_RELATIVE_TO_ROOT)))
                 .rootCAPath(parameterMap.get(ROOT_CA_PATH_PARAMETER_NAME).toString())
                 .build();
 
@@ -215,6 +217,13 @@ public class FleetProvisioningByClaimPlugin implements DeviceIdentityInterface {
                 .systemConfiguration(systemConfiguration)
                 .nucleusConfiguration(nucleusConfiguration)
                 .build();
+    }
+
+    static String getFileUriOrString(Path p) {
+        if (IS_WINDOWS) {
+            return p.toUri().toString();
+        }
+        return p.toString();
     }
 
     private void checkRequiredParameterPresent(Map<String, Object> parameterMap, List<String> errors,


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Greengrass Nucleus 2.5.0 introduced a new `SecurityService` which uses URIs to determine where to get the private key and certificate from. On Windows, this made it ambiguous since `C:/` is interpreted as a URI with a scheme of `C`. This change adds `file://` to the beginning of the string to make it an unambiguous file URI, but only for windows. This retains compatibility with older nucleus versions.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
