### PR TITLE
fix: revert return paths as URI and normalize paths

### DIFF
--- a/src/main/java/com/aws/greengrass/FleetProvisioningByClaimPlugin.java
+++ b/src/main/java/com/aws/greengrass/FleetProvisioningByClaimPlugin.java
@@ -206,10 +206,10 @@ public class FleetProvisioningByClaimPlugin implements DeviceIdentityInterface {
 
         SystemConfiguration systemConfiguration = SystemConfiguration.builder()
                 .thingName(registerThingResponse.thingName)
-                .privateKeyPath(getFileUriOrString(Paths.get(parameterMap.get(ROOT_PATH_PARAMETER_NAME).toString(),
-                        PRIVATE_KEY_PATH_RELATIVE_TO_ROOT)))
-                .certificateFilePath(getFileUriOrString(Paths.get(parameterMap.get(ROOT_PATH_PARAMETER_NAME).toString(),
-                        DEVICE_CERTIFICATE_PATH_RELATIVE_TO_ROOT)))
+                .privateKeyPath(Paths.get(parameterMap.get(ROOT_PATH_PARAMETER_NAME).toString(),
+                        PRIVATE_KEY_PATH_RELATIVE_TO_ROOT).normalize().toString())
+                .certificateFilePath(Paths.get(parameterMap.get(ROOT_PATH_PARAMETER_NAME).toString(),
+                        DEVICE_CERTIFICATE_PATH_RELATIVE_TO_ROOT).normalize().toString())
                 .rootCAPath(parameterMap.get(ROOT_CA_PATH_PARAMETER_NAME).toString())
                 .build();
 
@@ -217,13 +217,6 @@ public class FleetProvisioningByClaimPlugin implements DeviceIdentityInterface {
                 .systemConfiguration(systemConfiguration)
                 .nucleusConfiguration(nucleusConfiguration)
                 .build();
-    }
-
-    static String getFileUriOrString(Path p) {
-        if (IS_WINDOWS) {
-            return p.toUri().toString();
-        }
-        return p.toString();
     }
 
     private void checkRequiredParameterPresent(Map<String, Object> parameterMap, List<String> errors,


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Revert returning file paths as file URI because it's not backward-compatible with older nucleus.
Instead, return normalized paths. So on Windows, input paths with forward slash will be flipped to backward slash, which still fixes the problem that `C:/` will be treated as URI having schema of "C".

**Why is this change necessary:**
Backward-compatibility.

**How was this change tested:**
Updated existing unit tests.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
