### PR TITLE
fix: use custom runtime exception for better error reporting

### DIFF
--- a/src/main/java/com/aws/greengrass/DeviceProvisioningRuntimeException.java
+++ b/src/main/java/com/aws/greengrass/DeviceProvisioningRuntimeException.java
@@ -6,6 +6,8 @@
 package com.aws.greengrass;
 
 public class DeviceProvisioningRuntimeException extends RuntimeException {
+    static final long serialVersionUID = -7034897190745766939L;
+
     public DeviceProvisioningRuntimeException(String message) {
         super(message);
     }

--- a/src/main/java/com/aws/greengrass/DeviceProvisioningRuntimeException.java
+++ b/src/main/java/com/aws/greengrass/DeviceProvisioningRuntimeException.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass;
+
+public class DeviceProvisioningRuntimeException extends RuntimeException {
+    public DeviceProvisioningRuntimeException(String message) {
+        super(message);
+    }
+
+    public DeviceProvisioningRuntimeException(Throwable cause) {
+        super(cause);
+    }
+
+    public DeviceProvisioningRuntimeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/aws/greengrass/FleetProvisioningByClaimPlugin.java
+++ b/src/main/java/com/aws/greengrass/FleetProvisioningByClaimPlugin.java
@@ -166,7 +166,8 @@ public class FleetProvisioningByClaimPlugin implements DeviceIdentityInterface {
                     csr = new String(Files.readAllBytes(csrFile), StandardCharsets.UTF_8);
                 } catch (IOException | SecurityException ex) {
                     logger.atError().setCause(ex).log("Caught exception while reading the CSR file");
-                    throw new RuntimeException(ex);
+                    throw new DeviceProvisioningRuntimeException(
+                            "Failed to read CSR file " + csrFile.toAbsolutePath(), ex);
                 }
                 CreateCertificateFromCsrResponse response;
                 response = FutureExceptionHandler.getFutureAfterCompletion(
@@ -217,7 +218,7 @@ public class FleetProvisioningByClaimPlugin implements DeviceIdentityInterface {
         checkRequiredParameterPresent(parameterMap, errors, ROOT_PATH_PARAMETER_NAME);
 
         if (!errors.isEmpty()) {
-            throw new RuntimeException(errors.toString());
+            throw new IllegalArgumentException(errors.toString());
         }
     }
 
@@ -283,7 +284,7 @@ public class FleetProvisioningByClaimPlugin implements DeviceIdentityInterface {
             Platform.getInstance().setPermissions(FileSystemPermission.builder().ownerRead(true).build(), keyPath);
         } catch (IOException e) {
             logger.atError().log("Caught exception while writing certificate and private key to file");
-            throw new RuntimeException(e);
+            throw new DeviceProvisioningRuntimeException("Failed to write certificate and private key", e);
         }
     }
 
@@ -296,7 +297,7 @@ public class FleetProvisioningByClaimPlugin implements DeviceIdentityInterface {
                     .ownerRead(true).ownerWrite(true).ownerExecute(true).build(), certPath);
         } catch (IOException e) {
             logger.atError().log("Caught exception while writing certificate to file", e);
-            throw new RuntimeException(e);
+            throw new DeviceProvisioningRuntimeException("Failed to write certificate", e);
         }
     }
 }

--- a/src/main/java/com/aws/greengrass/FutureExceptionHandler.java
+++ b/src/main/java/com/aws/greengrass/FutureExceptionHandler.java
@@ -48,6 +48,7 @@ public final class FutureExceptionHandler {
      * @return The result of the future
      * @throws InterruptedException when thread is interrupted
      * @throws RetryableProvisioningException when retryable error happens like timeout
+     * @throws DeviceProvisioningRuntimeException when any other error happens
      * @throws RuntimeException when any other error happens
      */
     @SuppressWarnings("PMD.PreserveStackTrace")
@@ -65,7 +66,7 @@ public final class FutureExceptionHandler {
                 throw new RetryableProvisioningException(e1);
             } catch (ExecutionException e1) {
                 logger.atError().setCause(e1).log(errorMessage);
-                throw new RuntimeException(e1.getCause());
+                throw new DeviceProvisioningRuntimeException(e1.getCause());
             }
         } catch (TimeoutException e1) {
             logger.atWarn().setCause(e1).kv("retryable", true).log(errorMessage);

--- a/src/main/java/com/aws/greengrass/FutureExceptionHandler.java
+++ b/src/main/java/com/aws/greengrass/FutureExceptionHandler.java
@@ -34,7 +34,7 @@ public final class FutureExceptionHandler {
      * @throws InterruptedException {@link InterruptedException}
      * @throws RetryableProvisioningException {@link RetryableProvisioningException}
      */
-    public static <T> T getFutureAfterCompletion(Future<T> future, String... errorMessage)
+    public static <T> T getFutureAfterCompletion(Future<T> future, String errorMessage)
             throws InterruptedException, RetryableProvisioningException {
         return getFutureAfterCompletion(future, AWS_IOT_DEFAULT_TIMEOUT_SECONDS, errorMessage);
     }
@@ -52,7 +52,7 @@ public final class FutureExceptionHandler {
      * @throws RuntimeException when any other error happens
      */
     @SuppressWarnings("PMD.PreserveStackTrace")
-    public static <T> T getFutureAfterCompletion(Future<T> future, int timeout, String... errorMessage)
+    public static <T> T getFutureAfterCompletion(Future<T> future, int timeout, String errorMessage)
             throws InterruptedException, RetryableProvisioningException {
         try {
             return future.get(timeout, TimeUnit.SECONDS);

--- a/src/main/java/com/aws/greengrass/IotIdentityHelper.java
+++ b/src/main/java/com/aws/greengrass/IotIdentityHelper.java
@@ -71,7 +71,8 @@ public class IotIdentityHelper {
                 iotIdentityClient.SubscribeToCreateKeysAndCertificateAccepted(
                 createKeysAndCertificateSubscriptionRequest,
                 QualityOfService.AT_LEAST_ONCE, createFuture::complete);
-        FutureExceptionHandler.getFutureAfterCompletion(keysSubscribedAccepted, timeout);
+        FutureExceptionHandler.getFutureAfterCompletion(keysSubscribedAccepted, timeout,
+                "Failed to subscribe to create keys and certificate accepted topic");
 
         logger.atInfo().log("Subscribed to CreateKeysAndCertificateAccepted");
 
@@ -83,13 +84,15 @@ public class IotIdentityHelper {
                         RuntimeException e = new RuntimeException(errorResponse.errorMessage);
                         createFuture.completeExceptionally(e);
                     });
-        FutureExceptionHandler.getFutureAfterCompletion(keysSubscribedRejected, timeout);
+        FutureExceptionHandler.getFutureAfterCompletion(keysSubscribedRejected, timeout,
+                "Failed to subscribe to create keys and certificate rejected topic");
         logger.atInfo().log("Subscribed to CreateKeysAndCertificateRejected");
 
         CompletableFuture<Integer> publishKeys = iotIdentityClient.PublishCreateKeysAndCertificate(
                 new CreateKeysAndCertificateRequest(),
                 QualityOfService.AT_LEAST_ONCE);
-        FutureExceptionHandler.getFutureAfterCompletion(publishKeys);
+        FutureExceptionHandler.getFutureAfterCompletion(publishKeys,
+                "Failed to publish to create keys and certificate topic");
 
         logger.atInfo().log("Published to CreateKeysAndCertificate");
         return createFuture;
@@ -128,9 +131,9 @@ public class IotIdentityHelper {
         CompletableFuture<Integer> csrSubscribedAccepted =
                 iotIdentityClient.SubscribeToCreateCertificateFromCsrAccepted(
                 createCertificateFromCsrSubscriptionRequest,
-                QualityOfService.AT_LEAST_ONCE,
-                (response) -> createFuture.complete(response));
-        FutureExceptionHandler.getFutureAfterCompletion(csrSubscribedAccepted, timeout);
+                QualityOfService.AT_LEAST_ONCE, createFuture::complete);
+        FutureExceptionHandler.getFutureAfterCompletion(csrSubscribedAccepted, timeout,
+                "Failed to subscribe to create certificate from csr accepted topic");
 
         logger.atInfo().log("Subscribed to CreatedCertificateFromCsrAccepted");
 
@@ -142,7 +145,8 @@ public class IotIdentityHelper {
                         RuntimeException e = new RuntimeException(errorResponse.errorMessage);
                         createFuture.completeExceptionally(e);
                     });
-        FutureExceptionHandler.getFutureAfterCompletion(csrSubscribedRejected, timeout);
+        FutureExceptionHandler.getFutureAfterCompletion(csrSubscribedRejected, timeout,
+                "Failed to subscribe to create certificate from csr rejected topic");
         logger.atInfo().log("Subscribed to CreateCertificateFromCsrRejected");
         CreateCertificateFromCsrRequest createCertificateFromCsrRequest = new CreateCertificateFromCsrRequest();
         createCertificateFromCsrRequest.certificateSigningRequest = certificateSigningRequest;
@@ -150,7 +154,8 @@ public class IotIdentityHelper {
         CompletableFuture<Integer> publishCsr = iotIdentityClient.PublishCreateCertificateFromCsr(
                 createCertificateFromCsrRequest,
                 QualityOfService.AT_LEAST_ONCE);
-        FutureExceptionHandler.getFutureAfterCompletion(publishCsr);
+        FutureExceptionHandler.getFutureAfterCompletion(publishCsr,
+                "Failed to publish to create certificate from csr topic");
 
         logger.atInfo().log("Published to CreateCertificateFromCsr");
         return createFuture;
@@ -197,7 +202,8 @@ public class IotIdentityHelper {
                     logger.atInfo().log("Received register thing response");
                     registerFuture.complete(response);
                 }, registerFuture::completeExceptionally);
-        FutureExceptionHandler.getFutureAfterCompletion(subscribedRegisterAccepted, iotTimeout);
+        FutureExceptionHandler.getFutureAfterCompletion(subscribedRegisterAccepted, iotTimeout,
+                "Failed to subscribe to register thing accepted topic");
         logger.atInfo().log("Subscribed to SubscribeToRegisterThingAccepted");
 
         CompletableFuture<Integer> subscribedRegisterRejected = iotIdentityClient.SubscribeToRegisterThingRejected(
@@ -207,7 +213,8 @@ public class IotIdentityHelper {
                     RuntimeException e = new RuntimeException(errorResponse.errorMessage);
                     registerFuture.completeExceptionally(e);
                 }, registerFuture::completeExceptionally);
-        FutureExceptionHandler.getFutureAfterCompletion(subscribedRegisterRejected, iotTimeout);
+        FutureExceptionHandler.getFutureAfterCompletion(subscribedRegisterRejected, iotTimeout,
+                "Failed to subscribe to register thing rejected topic");
         logger.atInfo().log("Subscribed to SubscribeToRegisterThingRejected");
 
         RegisterThingRequest registerThingRequest = new RegisterThingRequest();

--- a/src/test/java/com/aws/greengrass/FleetProvisioningByClaimPluginTest.java
+++ b/src/test/java/com/aws/greengrass/FleetProvisioningByClaimPluginTest.java
@@ -121,7 +121,7 @@ public class FleetProvisioningByClaimPluginTest {
     public void GIVEN_required_params_not_provided_WHEN_plugin_invoked_THEN_validation_fails() {
         Map<String, Object> parameterMap = new HashMap<>();
         // empty map
-        Exception e = assertThrows(RuntimeException.class,
+        Exception e = assertThrows(IllegalArgumentException.class,
                 () -> fleetProvisioningByClaimPlugin.updateIdentityConfiguration(new ProvisionContext(DEFAULT_PROVISIONING_POLICY, parameterMap)));
         String errorMessage = e.getMessage();
         assertTrue(errorMessage.contains(String.format(MISSING_REQUIRED_PARAMETERS_ERROR_FORMAT,
@@ -262,12 +262,12 @@ public class FleetProvisioningByClaimPluginTest {
     @Test
     public void GIVEN_invalid_endpoint_passed_to_plugin_WHEN_plugin_called_THEN_runtime_exception() throws RetryableProvisioningException, InterruptedException {
         Map<String, Object> parameterMap = createRequiredParameterMap();
-        CompletableFuture completableFuture = new CompletableFuture();
+        CompletableFuture<Boolean> completableFuture = new CompletableFuture<>();
         completableFuture.completeExceptionally(new MqttException("Invalid Exception"));
         when(mockConnection.connect()).thenReturn(completableFuture);
         ProvisionContext provisionContext = new ProvisionContext(DEFAULT_PROVISIONING_POLICY, parameterMap);
 
-        assertThrows(RuntimeException.class,
+        assertThrows(DeviceProvisioningRuntimeException.class,
                () -> fleetProvisioningByClaimPlugin.updateIdentityConfiguration(provisionContext));
         verify(mockIotIdentityHelper, times(0)).createKeysAndCertificate();
         verify(mockIotIdentityHelper, times(0)).registerThing(eq(MOCK_CERTIFICATE_OWNERSHIP_TOKEN),


### PR DESCRIPTION
**Issue #, if available:**
Closes #13 

**Description of changes:**

Creates a new `DeviceProvisioningRuntimeException` to be more clear about the cause of errors as well as adding more context to help users debug. Logging in the FutureExceptionHandler was also incorrect due to it passing `String...` to the `.log()` method which expects a String.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
