### PR TITLE
fix: properly invoke withPort

### DIFF
--- a/src/main/java/com/aws/greengrass/MqttConnectionHelper.java
+++ b/src/main/java/com/aws/greengrass/MqttConnectionHelper.java
@@ -63,11 +63,11 @@ public class MqttConnectionHelper {
                 Class<?> classObj = builder.getClass();
                 try {
                     Method method = classObj.getDeclaredMethod("withPort", int.class);
-                    method.invoke(method, mqttConnectionParameters.getMqttPort());
+                    method.invoke(builder, mqttConnectionParameters.getMqttPort());
                 } catch (NoSuchMethodException e) {
                     try {
                         Method method = classObj.getDeclaredMethod("withPort", short.class);
-                        method.invoke(method, mqttConnectionParameters.getMqttPort().shortValue());
+                        method.invoke(builder, mqttConnectionParameters.getMqttPort().shortValue());
                     } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException ex) {
                         logger.atWarn().log("Can not successfully use port: "
                                 + mqttConnectionParameters.getMqttPort().shortValue(), ex);

--- a/src/test/java/com/aws/greengrass/MqttConnectionHelperTest.java
+++ b/src/test/java/com/aws/greengrass/MqttConnectionHelperTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass;
+
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.crt.io.ClientBootstrap;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+
+@ExtendWith({MockitoExtension.class, GGExtension.class})
+public class MqttConnectionHelperTest {
+
+    private static final String MOCK_IOT_DATA_ENDPOINT = "MOCK_IOT_DATA_ENDPOINT";
+    private static final String MOCK_CLIENT_ID = "MOCK_CLIENT_ID";
+    private static final Integer MOCK_PORT_NUMBER = 8883;
+
+    @TempDir
+    Path rootDir;
+    Path claimCertificatePath;
+    Path privateKeyPath;
+    Path rootCAPath;
+    private final ClientBootstrap mockClientBootstrap = new ClientBootstrap(null, null);
+    @BeforeEach
+    public void setup() throws IOException {
+        claimCertificatePath = rootDir.resolve("claimCert.crt");
+        Files.createFile(claimCertificatePath);
+        privateKeyPath = rootDir.resolve("privateKey.key");
+        Files.createFile(privateKeyPath);
+        rootCAPath = rootDir.resolve("rootCA.pem");
+        Files.createFile(rootCAPath);
+    }
+
+    @Test
+    public void GIVEN_MQTT_port_number_THEN_sdk_successfully_invoke_withPort_method(){
+        MqttConnectionHelper mockmqttConnectionHelper = new MqttConnectionHelper();
+        MqttConnectionHelper.MqttConnectionParameters parameters = createMqttConnectionParams();
+        assertDoesNotThrow(() -> mockmqttConnectionHelper.getMqttConnection(parameters));
+    }
+    private MqttConnectionHelper.MqttConnectionParameters createMqttConnectionParams() {
+        return new MqttConnectionHelper.MqttConnectionParameters(
+                claimCertificatePath.toString(),
+                privateKeyPath.toString(),
+                rootCAPath.toString(),
+                MOCK_IOT_DATA_ENDPOINT,
+                MOCK_CLIENT_ID,
+                MOCK_PORT_NUMBER,
+                mockClientBootstrap,
+                null
+        );
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fix on the error message `java.lang.NoSuchMethodError: software.amazon.awssdk.iot.AwsIotMqttConnectionBuilder.withPort(S)`
**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
