### PR TITLE
feat: configurable cert and key paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ This plugin takes following parameters
 
 ### Optional
 - **csrPath**: CSR file to be used for creating the device certificate from a CSR
+- **certPath**: Override the location where the device certificate is stored locally. Defaults to `**rootPath**/thingCert.crt`
+- **keyPath**: Override the location where the device private key is stored locally. Defaults to `**rootPath**/privKey.key`.
 - **deviceId**: The device identifier which will be used as client id in the mqtt connection to AWS IoT
 - **templateParameters**: Map<String, String> of parameters which will be passed to provisioning template 
 - **awsRegion**: AWS Region

--- a/src/main/java/com/aws/greengrass/FleetProvisioningByClaimPlugin.java
+++ b/src/main/java/com/aws/greengrass/FleetProvisioningByClaimPlugin.java
@@ -31,6 +31,7 @@ import software.amazon.awssdk.iot.iotidentity.model.RegisterThingResponse;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
@@ -59,7 +60,7 @@ public class FleetProvisioningByClaimPlugin implements DeviceIdentityInterface {
     static final String ROOT_PATH_PARAMETER_NAME = "rootPath";
     static final String MQTT_PORT_PARAMETER_NAME = "mqttPort";
 
-    // Optional Paramters
+    // Optional Parameters
     static final String DEVICE_ID_PARAMETER_NAME = "deviceId";
     static final String TEMPLATE_PARAMETERS_PARAMETER_NAME = "templateParameters";
     static final String AWS_REGION_PARAMETER_NAME = "awsRegion";
@@ -70,12 +71,14 @@ public class FleetProvisioningByClaimPlugin implements DeviceIdentityInterface {
     static final String PROXY_PASSWORD_PARAMETER_NAME = "proxyPassword";
     static final String CSR_PATH_PARAMETER_NAME = "csrPath";
     static final String CSR_PRIVATE_KEY_PATH_PARAMETER_NAME = "csrPrivateKeyPath";
+    static final String CERT_PATH_PARAMETER_NAME = "certPath";
+    static final String KEY_PATH_PARAMETER_NAME = "keyPath";
 
     static final String MISSING_REQUIRED_PARAMETERS_ERROR_FORMAT =
             "Required parameter %s missing for " + PLUGIN_NAME;
 
-    static final String DEVICE_CERTIFICATE_PATH_RELATIVE_TO_ROOT = "/thingCert.crt";
-    static final String PRIVATE_KEY_PATH_RELATIVE_TO_ROOT = "/privKey.key";
+    static final String DEFAULT_CERT_FILE = "thingCert.crt";
+    static final String DEFAULT_KEY_FILE = "privKey.key";
 
     public static final boolean IS_WINDOWS = System.getProperty("os.name").toLowerCase().contains("wind");
 
@@ -114,8 +117,6 @@ public class FleetProvisioningByClaimPlugin implements DeviceIdentityInterface {
         }
         String csrPath = parameterMap.get(CSR_PATH_PARAMETER_NAME) == null ? null
                 : parameterMap.get(CSR_PATH_PARAMETER_NAME).toString();
-        String csrPrivateKeyPath = parameterMap.get(CSR_PRIVATE_KEY_PATH_PARAMETER_NAME) == null ? null
-                : parameterMap.get(CSR_PRIVATE_KEY_PATH_PARAMETER_NAME).toString();
         String rootCaPath = parameterMap.get(ROOT_CA_PATH_PARAMETER_NAME).toString();
         String templateName = parameterMap.get(PROVISIONING_TEMPLATE_PARAMETER_NAME).toString();
         String clientId = parameterMap.get(DEVICE_ID_PARAMETER_NAME) == null ? UUID.randomUUID().toString()
@@ -163,16 +164,21 @@ public class FleetProvisioningByClaimPlugin implements DeviceIdentityInterface {
 
             IotIdentityHelper iotIdentityHelper = iotIdentityHelperFactory.getInstance(connection);
 
-            String certificateOwnershipToken = null;
+            Path certificatePath = getPathOrDefaultFromRoot(parameterMap, CERT_PATH_PARAMETER_NAME, DEFAULT_CERT_FILE);
+            Path privateKeyPath = getPathOrDefaultFromRoot(parameterMap, KEY_PATH_PARAMETER_NAME, DEFAULT_KEY_FILE);
+
+            String certificateOwnershipToken;
             if (csrPath == null || Utils.isEmpty(csrPath)) {
                 CreateKeysAndCertificateResponse response;
                 response = FutureExceptionHandler.getFutureAfterCompletion(iotIdentityHelper.createKeysAndCertificate(),
                         "Caught exception during PublishCreateKeysAndCertificate");
 
-                writeCertificateAndKeyToPath(response, parameterMap.get(ROOT_PATH_PARAMETER_NAME).toString());
+                writeCertificate(response, certificatePath);
+                writeKey(response, privateKeyPath);
+
                 certificateOwnershipToken = response.certificateOwnershipToken;
             } else {
-                Path csrFile = Paths.get(csrPath);
+                Path csrFile = getPath(parameterMap, CSR_PATH_PARAMETER_NAME);
                 String csr;
                 try {
                     csr = new String(Files.readAllBytes(csrFile), StandardCharsets.UTF_8);
@@ -186,11 +192,13 @@ public class FleetProvisioningByClaimPlugin implements DeviceIdentityInterface {
                         iotIdentityHelper.createCertificateFromCsr(csr),
                         "Caught exception during PublishCreateCertificateFromCsr");
 
-                writeCertificateToPath(response, parameterMap.get(ROOT_PATH_PARAMETER_NAME).toString());
-                copyPrivateKey(parameterMap.get(ROOT_PATH_PARAMETER_NAME).toString(), csrPrivateKeyPath);
+                Path csrPrivateKeyPath = getPath(parameterMap, CSR_PRIVATE_KEY_PATH_PARAMETER_NAME);
+                writeCertificate(response, certificatePath);
+                copyFile(csrPrivateKeyPath, privateKeyPath);
+                setFilePermissions(csrPrivateKeyPath);
+
                 certificateOwnershipToken = response.certificateOwnershipToken;
             }
-
 
             HashMap<String, String> templateParameterHashMap = new HashMap<>();
             if (templateParameters != null) {
@@ -259,12 +267,13 @@ public class FleetProvisioningByClaimPlugin implements DeviceIdentityInterface {
             nucleusConfiguration.setIotRoleAlias(parameterValue.toString());
         }
 
+        Path certificatePath = getPathOrDefaultFromRoot(parameterMap, CERT_PATH_PARAMETER_NAME, DEFAULT_CERT_FILE);
+        Path privateKeyPath = getPathOrDefaultFromRoot(parameterMap, KEY_PATH_PARAMETER_NAME, DEFAULT_KEY_FILE);
+
         SystemConfiguration systemConfiguration = SystemConfiguration.builder()
                 .thingName(registerThingResponse.thingName)
-                .privateKeyPath(Paths.get(parameterMap.get(ROOT_PATH_PARAMETER_NAME).toString(),
-                        PRIVATE_KEY_PATH_RELATIVE_TO_ROOT).normalize().toString())
-                .certificateFilePath(Paths.get(parameterMap.get(ROOT_PATH_PARAMETER_NAME).toString(),
-                        DEVICE_CERTIFICATE_PATH_RELATIVE_TO_ROOT).normalize().toString())
+                .privateKeyPath(privateKeyPath.toString())
+                .certificateFilePath(certificatePath.toString())
                 .rootCAPath(parameterMap.get(ROOT_CA_PATH_PARAMETER_NAME).toString())
                 .build();
 
@@ -284,54 +293,107 @@ public class FleetProvisioningByClaimPlugin implements DeviceIdentityInterface {
         }
     }
 
-    private void copyPrivateKey(String rootPath, String privateKeyPath) {
-        Path permPrivateKeyPath = Paths.get(rootPath, PRIVATE_KEY_PATH_RELATIVE_TO_ROOT);
+    private static Path getRootPath(Map<String, Object> parameterMap) {
+        return getPath(parameterMap, ROOT_PATH_PARAMETER_NAME);
+    }
+
+    private static Path getPath(Map<String, Object> parameterMap, String key) {
+        if (parameterMap.get(key) == null) {
+            throw new DeviceProvisioningRuntimeException(
+                    String.format("Config parameter %s is missing", key));
+        }
+        return getPath(parameterMap.get(key).toString());
+    }
+
+    private static Path getPath(String path) {
         try {
-            if (Files.notExists(permPrivateKeyPath)) {
-                Files.createFile(permPrivateKeyPath);
-            }
-            Files.copy(Paths.get(privateKeyPath), permPrivateKeyPath, StandardCopyOption.REPLACE_EXISTING);
-            Platform.getInstance().setPermissions(FileSystemPermission.builder().ownerRead(true)
-                    .ownerWrite(true).build(), permPrivateKeyPath);
-        } catch (IOException e) {
-            logger.atError().log("Caught exception while copying private key to root directory");
-            throw new DeviceProvisioningRuntimeException("Failed to copy private key to root directory", e);
+            return Paths.get(path).normalize();
+        } catch (InvalidPathException e) {
+            throw new DeviceProvisioningRuntimeException(
+                    String.format("Invalid path: %s", path), e);
         }
     }
 
-    private void writeCertificateAndKeyToPath(CreateKeysAndCertificateResponse response, String rootPath) {
-        try {
-            Path certPath = Paths.get(rootPath, DEVICE_CERTIFICATE_PATH_RELATIVE_TO_ROOT);
-            if (Files.notExists(certPath)) {
-                Files.createFile(certPath);
+    private static Path getPathOrDefaultFromRoot(Map<String, Object> parameterMap, String key, String defaultName) {
+        if (parameterMap.get(key) == null) {
+            // if not provided, result path relative to rootPath
+            Path rootPath = getRootPath(parameterMap);
+            try {
+                return rootPath.resolve(defaultName);
+            } catch (InvalidPathException e) {
+                throw new DeviceProvisioningRuntimeException(
+                        String.format("Invalid %s: %s. rootPath: %s",
+                                key, defaultName, rootPath), e);
             }
-            Files.write(certPath, response.certificatePem.getBytes(StandardCharsets.UTF_8));
-            Platform.getInstance().setPermissions(FileSystemPermission.builder().ownerRead(true)
-                .ownerWrite(true).build(), certPath);
-
-            Path keyPath = Paths.get(rootPath, PRIVATE_KEY_PATH_RELATIVE_TO_ROOT);
-            if (Files.notExists(keyPath)) {
-                Files.createFile(keyPath);
-            }
-            Files.write(keyPath, response.privateKey.getBytes(StandardCharsets.UTF_8));
-            Platform.getInstance().setPermissions(FileSystemPermission.builder().ownerRead(true)
-                .ownerWrite(true).build(), keyPath);
-        } catch (IOException e) {
-            logger.atError().log("Caught exception while writing certificate and private key to file");
-            throw new DeviceProvisioningRuntimeException("Failed to write certificate and private key", e);
+        } else {
+            return getPath(parameterMap.get(key).toString());
         }
     }
 
-    private void writeCertificateToPath(CreateCertificateFromCsrResponse response, String rootPath) {
+    private static void copyFile(Path src, Path dst) {
         try {
-            Path certPath = Paths.get(rootPath, DEVICE_CERTIFICATE_PATH_RELATIVE_TO_ROOT);
-            Files.createFile(certPath);
-            Files.write(certPath, response.certificatePem.getBytes(StandardCharsets.UTF_8));
-            Platform.getInstance().setPermissions(FileSystemPermission.builder().ownerRead(true)
-                .ownerWrite(true).build(), certPath);
+            createFile(dst);
+            Files.copy(src, dst, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            logger.atError().kv("src", src).kv("dst", dst)
+                    .log("Caught exception while copying file");
+            throw new DeviceProvisioningRuntimeException(
+                    String.format("Failed to copy %s to %s", src, dst), e);
+        }
+    }
+
+    private static void writeKey(CreateKeysAndCertificateResponse response, Path path) {
+        try {
+            writeFile(path, response.privateKey);
+            setFilePermissions(path);
         } catch (IOException e) {
             logger.atError().log("Caught exception while writing certificate to file", e);
             throw new DeviceProvisioningRuntimeException("Failed to write certificate", e);
+        }
+    }
+
+    private static void writeCertificate(CreateCertificateFromCsrResponse response, Path path) {
+        writeCertificate(response.certificatePem, path);
+    }
+
+    private static void writeCertificate(CreateKeysAndCertificateResponse response, Path path) {
+        writeCertificate(response.certificatePem, path);
+    }
+
+    private static void writeCertificate(String certificatePem, Path path) {
+        try {
+            writeFile(path, certificatePem);
+            setFilePermissions(path);
+        } catch (IOException e) {
+            logger.atError().log("Caught exception while writing certificate to file", e);
+            throw new DeviceProvisioningRuntimeException("Failed to write certificate", e);
+        }
+    }
+
+    private static void writeFile(Path file, String content) throws IOException {
+        createFile(file);
+        Files.write(file, content.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static void createFile(Path file) throws IOException {
+        Path parent = file.getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+        if (Files.notExists(file)) {
+            Files.createFile(file);
+        }
+    }
+
+    private static void setFilePermissions(Path file) {
+        try {
+            Platform.getInstance().setPermissions(FileSystemPermission.builder()
+                    .ownerRead(true)
+                    .ownerWrite(true)
+                    .build(), file);
+        } catch (IOException e) {
+            throw new DeviceProvisioningRuntimeException(
+                    String.format("Failed to set permissions on file %s", file), e);
         }
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

Closes https://github.com/aws-greengrass/aws-greengrass-fleet-provisioning-by-claim/issues/27

**Description of changes:**

Adds two new configuration parameters:
- **certPath**: Override the location where the device certificate is stored locally. Defaults to `**rootPath**/thingCert.crt`
- **keyPath**: Override the location where the device private key is stored locally. Defaults to `**rootPath**/privKey.key`.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
