### PR TITLE
chore: update param names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           python3 ./.github/scripts/cover2cover.py target/jacoco-report/jacoco.xml src/main/java > target/jacoco-report/cobertura.xml
         if: matrix.os == 'ubuntu-latest'
       - name: Upload Coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: matrix.os == 'ubuntu-latest'
         with:
           name: Coverage Report
@@ -48,7 +48,7 @@ jobs:
           cp target/jacoco-report/cobertura.xml ./pr/jacoco-report/cobertura.xml
         if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest'
       - name: Upload files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: pr
           path: pr/

--- a/src/main/java/com/aws/greengrass/FleetProvisioningByClaimPlugin.java
+++ b/src/main/java/com/aws/greengrass/FleetProvisioningByClaimPlugin.java
@@ -71,8 +71,8 @@ public class FleetProvisioningByClaimPlugin implements DeviceIdentityInterface {
     static final String PROXY_PASSWORD_PARAMETER_NAME = "proxyPassword";
     static final String CSR_PATH_PARAMETER_NAME = "csrPath";
     static final String CSR_PRIVATE_KEY_PATH_PARAMETER_NAME = "csrPrivateKeyPath";
-    static final String CERT_PATH_PARAMETER_NAME = "certPath";
-    static final String KEY_PATH_PARAMETER_NAME = "keyPath";
+    static final String CERT_PATH_PARAMETER_NAME = "certificatePath";
+    static final String KEY_PATH_PARAMETER_NAME = "privateKeyPath";
 
     static final String MISSING_REQUIRED_PARAMETERS_ERROR_FORMAT =
             "Required parameter %s missing for " + PLUGIN_NAME;

--- a/src/test/java/com/aws/greengrass/FleetProvisioningByClaimPluginTest.java
+++ b/src/test/java/com/aws/greengrass/FleetProvisioningByClaimPluginTest.java
@@ -191,8 +191,8 @@ public class FleetProvisioningByClaimPluginTest {
 
         Map<String, Object> parameterMap = createRequiredParameterMap();
         // override cert and key paths
-        parameterMap.put("certPath", certPath.toString());
-        parameterMap.put("keyPath", keyPath.toString());
+        parameterMap.put("certificatePath", certPath.toString());
+        parameterMap.put("privateKeyPath", keyPath.toString());
 
         ProvisionContext provisionContext = new ProvisionContext(DEFAULT_PROVISIONING_POLICY, parameterMap);
         when(mockIotIdentityHelper.createKeysAndCertificate()).thenReturn(createMockCreateKeysAndCertificateResponse());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Updating certificate and private key path parameter names to be consistent with existing parameters. The earlier names (`certPath` and `keyPath`) were quite crude.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
